### PR TITLE
feat: шорткаты, контекстное меню, новые markdown-действия

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { TitleBar } from './components/TitleBar/TitleBar';
 import { Toolbar } from './components/Toolbar/Toolbar';
 import { Editor } from './components/Editor/Editor';
 import { StatusBar } from './components/StatusBar/StatusBar';
+import { ContextMenu } from './components/ContextMenu/ContextMenu';
 import { useFile } from './hooks/useFile';
 import { useSettings } from './hooks/useSettings';
 import { useTheme } from './hooks/useTheme';
@@ -18,6 +19,9 @@ function App() {
   const editorMode = useAppStore((s) => s.editorMode);
   const setEditorMode = useAppStore((s) => s.setEditorMode);
   const setContent = useAppStore((s) => s.setContent);
+
+  // Состояние контекстного меню
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
 
   // Обработка открытия файла через ассоциацию (Windows)
   // Запрашиваем при монтировании приложения
@@ -75,12 +79,12 @@ function App() {
       save();
     }
     // Ctrl+Shift+S — Сохранить как
-    if (e.ctrlKey && e.shiftKey && e.key === 'S') {
+    if (e.ctrlKey && e.shiftKey && e.code === 'KeyS') {
       e.preventDefault();
       saveAs();
     }
     // Ctrl+Shift+T — Переключить тему
-    if (e.ctrlKey && e.shiftKey && e.key === 'T') {
+    if (e.ctrlKey && e.shiftKey && e.code === 'KeyT') {
       e.preventDefault();
       toggleTheme();
     }
@@ -94,8 +98,8 @@ function App() {
       e.preventDefault();
       changeFontSize(fontSize + 1);
     }
-    // Ctrl+- — Уменьшить шрифт
-    if (e.ctrlKey && e.key === '-') {
+    // Ctrl+- — Уменьшить шрифт (без Shift, иначе конфликт с горизонтальной линией)
+    if (e.ctrlKey && !e.shiftKey && e.key === '-') {
       e.preventDefault();
       changeFontSize(fontSize - 1);
     }
@@ -114,17 +118,17 @@ function App() {
       applyMarkdownAction('italic');
     }
     // Ctrl+Shift+X — Зачёркнутый
-    if (e.ctrlKey && e.shiftKey && e.key === 'X') {
+    if (e.ctrlKey && e.shiftKey && e.code === 'KeyX') {
       e.preventDefault();
       applyMarkdownAction('strikethrough');
     }
     // Ctrl+K — Ссылка
-    if (e.ctrlKey && !e.shiftKey && e.key === 'k') {
+    if (e.ctrlKey && !e.shiftKey && e.code === 'KeyK') {
       e.preventDefault();
       applyMarkdownAction('link');
     }
     // Ctrl+Shift+K — Изображение
-    if (e.ctrlKey && e.shiftKey && e.key === 'K') {
+    if (e.ctrlKey && e.shiftKey && e.code === 'KeyK') {
       e.preventDefault();
       applyMarkdownAction('image');
     }
@@ -134,17 +138,17 @@ function App() {
       applyMarkdownAction('inlineCode');
     }
     // Ctrl+Shift+. — Цитата
-    if (e.ctrlKey && e.shiftKey && e.key === '>') {
+    if (e.ctrlKey && e.shiftKey && e.code === 'Period') {
       e.preventDefault();
       applyMarkdownAction('blockquote');
     }
     // Ctrl+Shift+8 — Маркированный список
-    if (e.ctrlKey && e.shiftKey && e.key === '*') {
+    if (e.ctrlKey && e.shiftKey && e.code === 'Digit8') {
       e.preventDefault();
       applyMarkdownAction('unorderedList');
     }
     // Ctrl+Shift+7 — Нумерованный список
-    if (e.ctrlKey && e.shiftKey && e.key === '&') {
+    if (e.ctrlKey && e.shiftKey && e.code === 'Digit7') {
       e.preventDefault();
       applyMarkdownAction('orderedList');
     }
@@ -161,6 +165,26 @@ function App() {
       e.preventDefault();
       applyMarkdownAction('heading3');
     }
+    // Ctrl+T — Таблица
+    if (e.ctrlKey && !e.shiftKey && e.code === 'KeyT') {
+      e.preventDefault();
+      applyMarkdownAction('table');
+    }
+    // Ctrl+Shift+C — Чекбокс
+    if (e.ctrlKey && e.shiftKey && e.code === 'KeyC') {
+      e.preventDefault();
+      applyMarkdownAction('checkbox');
+    }
+    // Ctrl+Shift+E — Блок кода
+    if (e.ctrlKey && e.shiftKey && e.code === 'KeyE') {
+      e.preventDefault();
+      applyMarkdownAction('codeBlock');
+    }
+    // Ctrl+Shift+- — Горизонтальная линия
+    if (e.ctrlKey && e.shiftKey && e.code === 'Minus') {
+      e.preventDefault();
+      applyMarkdownAction('horizontalRule');
+    }
   }, [open, save, saveAs, toggleTheme, editorMode, setEditorMode, changeFontSize, fontSize, applyMarkdownAction, setContent]);
 
   useEffect(() => {
@@ -168,12 +192,34 @@ function App() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleKeyDown]);
 
+  // Контекстное меню (только в source-режиме)
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    if (editorMode !== 'source') return;
+    const target = e.target as HTMLElement;
+    if (!target.closest('.editor-source')) return;
+    e.preventDefault();
+    setContextMenu({ x: e.clientX, y: e.clientY });
+  }, [editorMode]);
+
+  const handleContextMenuAction = useCallback((action: MarkdownAction) => {
+    setContextMenu(null);
+    applyMarkdownAction(action);
+  }, [applyMarkdownAction]);
+
   return (
-    <div className="app">
+    <div className="app" onContextMenu={handleContextMenu}>
       <TitleBar />
       <Toolbar />
       <Editor />
       <StatusBar />
+      {contextMenu && (
+        <ContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          onAction={handleContextMenuAction}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/About/AboutDialog.tsx
+++ b/src/components/About/AboutDialog.tsx
@@ -1,11 +1,16 @@
+import { useState } from 'react';
 import { useAppStore } from '../../stores/appStore';
 import { getTranslations } from '../../i18n';
 import { openUrl } from '@tauri-apps/plugin-opener';
+import { MarkdownReference } from './MarkdownReference';
+import { ShortcutsReference } from './ShortcutsReference';
 import './about.css';
 
 const VERSION = '0.1.0';
 const GITHUB_URL = 'https://github.com/BrianIS8090/';
 const EMAIL = 'ilmir8090@gmail.com';
+
+type HelpTab = 'about' | 'reference' | 'shortcuts';
 
 interface AboutDialogProps {
   onClose: () => void;
@@ -14,6 +19,7 @@ interface AboutDialogProps {
 export function AboutDialog({ onClose }: AboutDialogProps) {
   const language = useAppStore((s) => s.language);
   const t = getTranslations(language);
+  const [activeTab, setActiveTab] = useState<HelpTab>('about');
 
   const handleOpenLink = async (url: string) => {
     try {
@@ -31,39 +37,68 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
           <h2>Markdown Redactor</h2>
           <span className="about-version">{t.version}: {VERSION}</span>
         </div>
-        
-        <div className="about-content">
-          <p className="about-description">{t.description}</p>
-          
-          <div className="about-section">
-            <h3>{t.license}</h3>
-            <p>{t.mitLicense}</p>
-          </div>
-          
-          <div className="about-section">
-            <h3>{t.author}</h3>
-            <p>BrianIS</p>
-          </div>
-          
-          <div className="about-section">
-            <h3>{t.contact}</h3>
-            <div className="about-links">
-              <button 
-                className="about-link" 
-                onClick={() => handleOpenLink(GITHUB_URL)}
-              >
-                GitHub
-              </button>
-              <button 
-                className="about-link" 
-                onClick={() => handleOpenLink(`mailto:${EMAIL}`)}
-              >
-                {EMAIL}
-              </button>
-            </div>
-          </div>
+
+        <div className="about-tabs">
+          <button
+            className={`about-tab ${activeTab === 'about' ? 'about-tab--active' : ''}`}
+            onClick={() => setActiveTab('about')}
+          >
+            {t.tabAbout}
+          </button>
+          <button
+            className={`about-tab ${activeTab === 'reference' ? 'about-tab--active' : ''}`}
+            onClick={() => setActiveTab('reference')}
+          >
+            {t.tabReference}
+          </button>
+          <button
+            className={`about-tab ${activeTab === 'shortcuts' ? 'about-tab--active' : ''}`}
+            onClick={() => setActiveTab('shortcuts')}
+          >
+            {t.tabShortcuts}
+          </button>
         </div>
-        
+
+        <div className="about-content">
+          {activeTab === 'about' && (
+            <>
+              <p className="about-description">{t.description}</p>
+
+              <div className="about-section">
+                <h3>{t.license}</h3>
+                <p>{t.mitLicense}</p>
+              </div>
+
+              <div className="about-section">
+                <h3>{t.author}</h3>
+                <p>BrianIS</p>
+              </div>
+
+              <div className="about-section">
+                <h3>{t.contact}</h3>
+                <div className="about-links">
+                  <button
+                    className="about-link"
+                    onClick={() => handleOpenLink(GITHUB_URL)}
+                  >
+                    GitHub
+                  </button>
+                  <button
+                    className="about-link"
+                    onClick={() => handleOpenLink(`mailto:${EMAIL}`)}
+                  >
+                    {EMAIL}
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
+
+          {activeTab === 'reference' && <MarkdownReference t={t} />}
+
+          {activeTab === 'shortcuts' && <ShortcutsReference t={t} />}
+        </div>
+
         <div className="about-footer">
           <button className="about-close-btn" onClick={onClose}>
             {t.close}

--- a/src/components/About/MarkdownReference.tsx
+++ b/src/components/About/MarkdownReference.tsx
@@ -1,0 +1,57 @@
+// Справочник символов Markdown-разметки
+
+import type { Translations } from '../../i18n/ru';
+
+interface MarkdownReferenceProps {
+  t: Translations;
+}
+
+interface RefItem {
+  syntax: string;
+  descKey: keyof Translations;
+}
+
+const REFERENCE_ITEMS: RefItem[] = [
+  { syntax: '# текст', descKey: 'refHeading1' },
+  { syntax: '## текст', descKey: 'refHeading2' },
+  { syntax: '### текст', descKey: 'refHeading3' },
+  { syntax: '**текст**', descKey: 'refBold' },
+  { syntax: '*текст*', descKey: 'refItalic' },
+  { syntax: '~~текст~~', descKey: 'refStrikethrough' },
+  { syntax: '[текст](url)', descKey: 'refLink' },
+  { syntax: '![alt](url)', descKey: 'refImage' },
+  { syntax: '`код`', descKey: 'refInlineCode' },
+  { syntax: '```\\nкод\\n```', descKey: 'refCodeBlock' },
+  { syntax: '> цитата', descKey: 'refBlockquote' },
+  { syntax: '- элемент', descKey: 'refUnorderedList' },
+  { syntax: '1. элемент', descKey: 'refOrderedList' },
+  { syntax: '---', descKey: 'refHorizontalRule' },
+  { syntax: '| A | B |\\n|---|---|\\n| 1 | 2 |', descKey: 'refTable' },
+  { syntax: '- [ ] задача', descKey: 'refCheckbox' },
+  { syntax: '- [x] задача', descKey: 'refCheckboxChecked' },
+];
+
+export function MarkdownReference({ t }: MarkdownReferenceProps) {
+  return (
+    <div className="md-reference">
+      <table className="md-reference-table">
+        <thead>
+          <tr>
+            <th>{t.refSyntax}</th>
+            <th>{t.refDescription}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {REFERENCE_ITEMS.map((item) => (
+            <tr key={item.descKey}>
+              <td>
+                <code className="md-reference-syntax">{item.syntax}</code>
+              </td>
+              <td>{t[item.descKey] as string}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/About/ShortcutsReference.tsx
+++ b/src/components/About/ShortcutsReference.tsx
@@ -49,6 +49,10 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: 'Ctrl+1', descKey: 'shortcut_heading1' },
       { keys: 'Ctrl+2', descKey: 'shortcut_heading2' },
       { keys: 'Ctrl+3', descKey: 'shortcut_heading3' },
+      { keys: 'Ctrl+T', descKey: 'shortcut_table' },
+      { keys: 'Ctrl+Shift+C', descKey: 'shortcut_checkbox' },
+      { keys: 'Ctrl+Shift+E', descKey: 'shortcut_codeBlock' },
+      { keys: 'Ctrl+Shift+-', descKey: 'shortcut_horizontalRule' },
     ],
   },
 ];

--- a/src/components/About/ShortcutsReference.tsx
+++ b/src/components/About/ShortcutsReference.tsx
@@ -1,0 +1,78 @@
+// Справочник горячих клавиш
+
+import type { Translations } from '../../i18n/ru';
+
+interface ShortcutsReferenceProps {
+  t: Translations;
+}
+
+interface ShortcutItem {
+  keys: string;
+  descKey: keyof Translations;
+}
+
+interface ShortcutGroup {
+  titleKey: keyof Translations;
+  items: ShortcutItem[];
+}
+
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    titleKey: 'shortcutCategory_file',
+    items: [
+      { keys: 'Ctrl+O', descKey: 'shortcut_open' },
+      { keys: 'Ctrl+S', descKey: 'shortcut_save' },
+      { keys: 'Ctrl+Shift+S', descKey: 'shortcut_saveAs' },
+    ],
+  },
+  {
+    titleKey: 'shortcutCategory_editor',
+    items: [
+      { keys: 'Ctrl+Shift+T', descKey: 'shortcut_toggleTheme' },
+      { keys: 'Ctrl+/', descKey: 'shortcut_toggleMode' },
+      { keys: 'Ctrl++', descKey: 'shortcut_increaseFontSize' },
+      { keys: 'Ctrl+-', descKey: 'shortcut_decreaseFontSize' },
+    ],
+  },
+  {
+    titleKey: 'shortcutCategory_markdown',
+    items: [
+      { keys: 'Ctrl+B', descKey: 'shortcut_bold' },
+      { keys: 'Ctrl+I', descKey: 'shortcut_italic' },
+      { keys: 'Ctrl+Shift+X', descKey: 'shortcut_strikethrough' },
+      { keys: 'Ctrl+K', descKey: 'shortcut_link' },
+      { keys: 'Ctrl+Shift+K', descKey: 'shortcut_image' },
+      { keys: 'Ctrl+E', descKey: 'shortcut_inlineCode' },
+      { keys: 'Ctrl+Shift+.', descKey: 'shortcut_blockquote' },
+      { keys: 'Ctrl+Shift+8', descKey: 'shortcut_unorderedList' },
+      { keys: 'Ctrl+Shift+7', descKey: 'shortcut_orderedList' },
+      { keys: 'Ctrl+1', descKey: 'shortcut_heading1' },
+      { keys: 'Ctrl+2', descKey: 'shortcut_heading2' },
+      { keys: 'Ctrl+3', descKey: 'shortcut_heading3' },
+    ],
+  },
+];
+
+export function ShortcutsReference({ t }: ShortcutsReferenceProps) {
+  return (
+    <div className="shortcuts-reference">
+      {SHORTCUT_GROUPS.map((group) => (
+        <div key={group.titleKey} className="shortcuts-group">
+          <h4 className="shortcuts-group-title">
+            {t[group.titleKey] as string}
+          </h4>
+          <div className="shortcuts-list">
+            {group.items.map((item) => (
+              <div key={item.descKey} className="shortcut-row">
+                <span className="shortcut-desc">
+                  {t[item.descKey] as string}
+                </span>
+                <kbd className="shortcut-keys">{item.keys}</kbd>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/About/about.css
+++ b/src/components/About/about.css
@@ -17,8 +17,11 @@
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
-  max-width: 420px;
+  max-width: 520px;
   width: 90%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 
@@ -49,8 +52,41 @@
   margin-top: 4px;
 }
 
+/* Табы */
+.about-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-tertiary);
+  padding: 0 16px;
+}
+
+.about-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.about-tab:hover {
+  color: var(--text-primary);
+  background: var(--hover-bg);
+}
+
+.about-tab--active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
 .about-content {
   padding: 20px 24px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
 }
 
 .about-description {
@@ -127,4 +163,102 @@
 
 .about-close-btn:hover {
   background: var(--accent-hover);
+}
+
+/* Справочник Markdown */
+.md-reference {
+  overflow-x: auto;
+}
+
+.md-reference-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.md-reference-table th {
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 2px solid var(--border);
+}
+
+.md-reference-table td {
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-primary);
+  vertical-align: middle;
+}
+
+.md-reference-table tr:last-child td {
+  border-bottom: none;
+}
+
+.md-reference-table tr:hover td {
+  background: var(--hover-bg);
+}
+
+.md-reference-syntax {
+  background: var(--hover-bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 2px 6px;
+  font-family: 'Cascadia Code', 'Consolas', monospace;
+  font-size: 12px;
+  white-space: pre;
+  color: var(--accent);
+}
+
+/* Горячие клавиши */
+.shortcuts-reference {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.shortcuts-group-title {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.shortcuts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.shortcut-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: var(--radius);
+}
+
+.shortcut-row:hover {
+  background: var(--hover-bg);
+}
+
+.shortcut-desc {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.shortcut-keys {
+  background: var(--hover-bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-family: 'Cascadia Code', 'Consolas', monospace;
+  font-size: 12px;
+  color: var(--text-secondary);
+  box-shadow: 0 1px 0 var(--border);
 }

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -1,0 +1,122 @@
+// Контекстное меню для вставки Markdown-разметки
+
+import { useEffect, useRef } from 'react';
+import { useAppStore } from '../../stores/appStore';
+import { getTranslations, type Translations } from '../../i18n';
+import type { MarkdownAction } from '../../utils/markdownInsert';
+import './contextMenu.css';
+
+interface ContextMenuProps {
+  x: number;
+  y: number;
+  onAction: (action: MarkdownAction) => void;
+  onClose: () => void;
+}
+
+interface MenuItem {
+  action: MarkdownAction;
+  labelKey: keyof Translations;
+  shortcut: string;
+}
+
+interface MenuGroup {
+  titleKey: keyof Translations;
+  items: MenuItem[];
+}
+
+const MENU_GROUPS: MenuGroup[] = [
+  {
+    titleKey: 'contextMenu_formatting',
+    items: [
+      { action: 'bold', labelKey: 'shortcut_bold', shortcut: 'Ctrl+B' },
+      { action: 'italic', labelKey: 'shortcut_italic', shortcut: 'Ctrl+I' },
+      { action: 'strikethrough', labelKey: 'shortcut_strikethrough', shortcut: 'Ctrl+Shift+X' },
+      { action: 'inlineCode', labelKey: 'shortcut_inlineCode', shortcut: 'Ctrl+E' },
+    ],
+  },
+  {
+    titleKey: 'contextMenu_insert',
+    items: [
+      { action: 'link', labelKey: 'shortcut_link', shortcut: 'Ctrl+K' },
+      { action: 'image', labelKey: 'shortcut_image', shortcut: 'Ctrl+Shift+K' },
+      { action: 'table', labelKey: 'shortcut_table', shortcut: 'Ctrl+T' },
+      { action: 'checkbox', labelKey: 'shortcut_checkbox', shortcut: 'Ctrl+Shift+C' },
+      { action: 'codeBlock', labelKey: 'shortcut_codeBlock', shortcut: 'Ctrl+Shift+E' },
+      { action: 'horizontalRule', labelKey: 'shortcut_horizontalRule', shortcut: 'Ctrl+Shift+-' },
+    ],
+  },
+  {
+    titleKey: 'contextMenu_blocks',
+    items: [
+      { action: 'heading1', labelKey: 'shortcut_heading1', shortcut: 'Ctrl+1' },
+      { action: 'heading2', labelKey: 'shortcut_heading2', shortcut: 'Ctrl+2' },
+      { action: 'heading3', labelKey: 'shortcut_heading3', shortcut: 'Ctrl+3' },
+      { action: 'blockquote', labelKey: 'shortcut_blockquote', shortcut: 'Ctrl+Shift+.' },
+      { action: 'unorderedList', labelKey: 'shortcut_unorderedList', shortcut: 'Ctrl+Shift+8' },
+      { action: 'orderedList', labelKey: 'shortcut_orderedList', shortcut: 'Ctrl+Shift+7' },
+    ],
+  },
+];
+
+export function ContextMenu({ x, y, onAction, onClose }: ContextMenuProps) {
+  const language = useAppStore((s) => s.language);
+  const t = getTranslations(language);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Закрытие по клику вне меню или Escape
+  useEffect(() => {
+    const handleClick = () => onClose();
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('click', handleClick);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('click', handleClick);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
+
+  // Корректировка позиции, чтобы меню не вышло за экран
+  useEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const rect = menu.getBoundingClientRect();
+    if (rect.right > window.innerWidth) {
+      menu.style.left = `${window.innerWidth - rect.width - 4}px`;
+    }
+    if (rect.bottom > window.innerHeight) {
+      menu.style.top = `${window.innerHeight - rect.height - 4}px`;
+    }
+  }, [x, y]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="context-menu"
+      style={{ left: x, top: y }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {MENU_GROUPS.map((group, gi) => (
+        <div key={group.titleKey}>
+          {gi > 0 && <div className="context-menu-separator" />}
+          <div className="context-menu-group-title">
+            {t[group.titleKey] as string}
+          </div>
+          {group.items.map((item) => (
+            <button
+              key={item.action}
+              className="context-menu-item"
+              onClick={() => onAction(item.action)}
+            >
+              <span className="context-menu-label">
+                {t[item.labelKey] as string}
+              </span>
+              <span className="context-menu-shortcut">{item.shortcut}</span>
+            </button>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ContextMenu/contextMenu.css
+++ b/src/components/ContextMenu/contextMenu.css
@@ -1,0 +1,65 @@
+/* Контекстное меню */
+.context-menu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 220px;
+  max-width: 300px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  padding: 4px;
+  backdrop-filter: blur(20px);
+}
+
+.context-menu-group-title {
+  padding: 4px 10px 2px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  user-select: none;
+}
+
+.context-menu-separator {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 8px;
+}
+
+.context-menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 5px 10px;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  gap: 16px;
+  text-align: left;
+}
+
+.context-menu-item:hover {
+  background: var(--hover-bg);
+}
+
+.context-menu-item:active {
+  background: var(--active-bg);
+}
+
+.context-menu-label {
+  flex: 1;
+  white-space: nowrap;
+}
+
+.context-menu-shortcut {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -6,24 +6,24 @@ export const en: Translations = {
   save: 'Save',
   saveAs: 'Save As',
   help: 'Help',
-  
+
   // Theme
   themeLight: 'Light',
   themeDark: 'Dark',
   themeSystem: 'System',
-  
+
   // Editor mode
   visualMode: 'Visual',
   sourceMode: 'Source',
-  
+
   // Status bar
   newFile: 'New File',
   words: ['word', 'words', 'words'] as [string, string, string],
   chars: ['char', 'chars', 'chars'] as [string, string, string],
-  
+
   // Editor
   placeholder: 'Start writing...',
-  
+
   // About
   about: 'About',
   version: 'Version',
@@ -33,7 +33,60 @@ export const en: Translations = {
   author: 'Author',
   contact: 'Contact',
   close: 'Close',
-  
+
+  // Help dialog tabs
+  tabAbout: 'About',
+  tabReference: 'Reference',
+  tabShortcuts: 'Shortcuts',
+
+  // Markdown reference
+  markdownReference: 'Markdown Reference',
+  refSyntax: 'Syntax',
+  refDescription: 'Description',
+  refExample: 'Example',
+  refHeading1: 'Heading 1',
+  refHeading2: 'Heading 2',
+  refHeading3: 'Heading 3',
+  refBold: 'Bold',
+  refItalic: 'Italic',
+  refStrikethrough: 'Strikethrough',
+  refLink: 'Link',
+  refImage: 'Image',
+  refInlineCode: 'Inline code',
+  refCodeBlock: 'Code block',
+  refBlockquote: 'Blockquote',
+  refUnorderedList: 'Unordered list',
+  refOrderedList: 'Ordered list',
+  refHorizontalRule: 'Horizontal rule',
+  refTable: 'Table',
+  refCheckbox: 'Checkbox',
+  refCheckboxChecked: 'Checkbox (checked)',
+
+  // Shortcuts
+  shortcutsTitle: 'Keyboard Shortcuts',
+  shortcutCategory_file: 'File',
+  shortcutCategory_editor: 'Editor',
+  shortcutCategory_markdown: 'Insert Markdown',
+  shortcut_open: 'Open file',
+  shortcut_save: 'Save',
+  shortcut_saveAs: 'Save as',
+  shortcut_toggleTheme: 'Toggle theme',
+  shortcut_toggleMode: 'Toggle mode',
+  shortcut_increaseFontSize: 'Increase font',
+  shortcut_decreaseFontSize: 'Decrease font',
+  shortcut_bold: 'Bold',
+  shortcut_italic: 'Italic',
+  shortcut_strikethrough: 'Strikethrough',
+  shortcut_link: 'Link',
+  shortcut_image: 'Image',
+  shortcut_inlineCode: 'Inline code',
+  shortcut_blockquote: 'Blockquote',
+  shortcut_unorderedList: 'Unordered list',
+  shortcut_orderedList: 'Ordered list',
+  shortcut_heading1: 'Heading 1',
+  shortcut_heading2: 'Heading 2',
+  shortcut_heading3: 'Heading 3',
+
   // Tooltips
   openTooltip: 'Open (Ctrl+O)',
   saveTooltip: 'Save (Ctrl+S)',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -86,6 +86,15 @@ export const en: Translations = {
   shortcut_heading1: 'Heading 1',
   shortcut_heading2: 'Heading 2',
   shortcut_heading3: 'Heading 3',
+  shortcut_table: 'Table',
+  shortcut_checkbox: 'Checkbox',
+  shortcut_codeBlock: 'Code block',
+  shortcut_horizontalRule: 'Horizontal rule',
+
+  // Context menu
+  contextMenu_formatting: 'Formatting',
+  contextMenu_insert: 'Insert',
+  contextMenu_blocks: 'Blocks',
 
   // Tooltips
   openTooltip: 'Open (Ctrl+O)',

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -4,24 +4,24 @@ export const ru = {
   save: 'Сохранить',
   saveAs: 'Сохранить как',
   help: 'Справка',
-  
+
   // Тема
   themeLight: 'Светлая',
   themeDark: 'Тёмная',
   themeSystem: 'Системная',
-  
+
   // Режим редактора
   visualMode: 'Визуальный',
   sourceMode: 'Исходный',
-  
+
   // Статус-бар
   newFile: 'Новый файл',
   words: ['слово', 'слова', 'слов'] as [string, string, string],
   chars: ['символ', 'символа', 'символов'] as [string, string, string],
-  
+
   // Редактор
   placeholder: 'Начните писать...',
-  
+
   // О программе
   about: 'О программе',
   version: 'Версия',
@@ -31,7 +31,60 @@ export const ru = {
   author: 'Автор',
   contact: 'Контакт',
   close: 'Закрыть',
-  
+
+  // Табы диалога справки
+  tabAbout: 'О программе',
+  tabReference: 'Справочник',
+  tabShortcuts: 'Горячие клавиши',
+
+  // Справочник Markdown
+  markdownReference: 'Справочник Markdown',
+  refSyntax: 'Синтаксис',
+  refDescription: 'Описание',
+  refExample: 'Пример',
+  refHeading1: 'Заголовок 1',
+  refHeading2: 'Заголовок 2',
+  refHeading3: 'Заголовок 3',
+  refBold: 'Жирный текст',
+  refItalic: 'Курсив',
+  refStrikethrough: 'Зачёркнутый',
+  refLink: 'Ссылка',
+  refImage: 'Изображение',
+  refInlineCode: 'Инлайн-код',
+  refCodeBlock: 'Блок кода',
+  refBlockquote: 'Цитата',
+  refUnorderedList: 'Маркированный список',
+  refOrderedList: 'Нумерованный список',
+  refHorizontalRule: 'Горизонтальная линия',
+  refTable: 'Таблица',
+  refCheckbox: 'Чекбокс',
+  refCheckboxChecked: 'Чекбокс (отмечен)',
+
+  // Горячие клавиши
+  shortcutsTitle: 'Горячие клавиши',
+  shortcutCategory_file: 'Файл',
+  shortcutCategory_editor: 'Редактор',
+  shortcutCategory_markdown: 'Вставка Markdown',
+  shortcut_open: 'Открыть файл',
+  shortcut_save: 'Сохранить',
+  shortcut_saveAs: 'Сохранить как',
+  shortcut_toggleTheme: 'Переключить тему',
+  shortcut_toggleMode: 'Переключить режим',
+  shortcut_increaseFontSize: 'Увеличить шрифт',
+  shortcut_decreaseFontSize: 'Уменьшить шрифт',
+  shortcut_bold: 'Жирный',
+  shortcut_italic: 'Курсив',
+  shortcut_strikethrough: 'Зачёркнутый',
+  shortcut_link: 'Ссылка',
+  shortcut_image: 'Изображение',
+  shortcut_inlineCode: 'Инлайн-код',
+  shortcut_blockquote: 'Цитата',
+  shortcut_unorderedList: 'Маркированный список',
+  shortcut_orderedList: 'Нумерованный список',
+  shortcut_heading1: 'Заголовок 1',
+  shortcut_heading2: 'Заголовок 2',
+  shortcut_heading3: 'Заголовок 3',
+
   // Подсказки
   openTooltip: 'Открыть (Ctrl+O)',
   saveTooltip: 'Сохранить (Ctrl+S)',

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -84,6 +84,15 @@ export const ru = {
   shortcut_heading1: 'Заголовок 1',
   shortcut_heading2: 'Заголовок 2',
   shortcut_heading3: 'Заголовок 3',
+  shortcut_table: 'Таблица',
+  shortcut_checkbox: 'Чекбокс',
+  shortcut_codeBlock: 'Блок кода',
+  shortcut_horizontalRule: 'Горизонтальная линия',
+
+  // Контекстное меню
+  contextMenu_formatting: 'Форматирование',
+  contextMenu_insert: 'Вставка',
+  contextMenu_blocks: 'Блоки',
 
   // Подсказки
   openTooltip: 'Открыть (Ctrl+O)',

--- a/src/test/markdownInsert.test.ts
+++ b/src/test/markdownInsert.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { insertMarkdown } from '../utils/markdownInsert';
+
+describe('insertMarkdown', () => {
+  describe('wrapSelection — оборачивание выделенного текста', () => {
+    it('bold: оборачивает выделение в **', () => {
+      const result = insertMarkdown('hello world', 6, 11, 'bold');
+      expect(result.value).toBe('hello **world**');
+      expect(result.selectionStart).toBe(8);
+      expect(result.selectionEnd).toBe(13);
+    });
+
+    it('bold: вставляет плейсхолдер без выделения', () => {
+      const result = insertMarkdown('hello ', 6, 6, 'bold');
+      expect(result.value).toBe('hello **текст**');
+      expect(result.selectionStart).toBe(8);
+      expect(result.selectionEnd).toBe(13);
+    });
+
+    it('italic: оборачивает в *', () => {
+      const result = insertMarkdown('test', 0, 4, 'italic');
+      expect(result.value).toBe('*test*');
+    });
+
+    it('strikethrough: оборачивает в ~~', () => {
+      const result = insertMarkdown('text', 0, 4, 'strikethrough');
+      expect(result.value).toBe('~~text~~');
+    });
+
+    it('inlineCode: оборачивает в `', () => {
+      const result = insertMarkdown('code', 0, 4, 'inlineCode');
+      expect(result.value).toBe('`code`');
+    });
+
+    it('link: оборачивает в [](url)', () => {
+      const result = insertMarkdown('click', 0, 5, 'link');
+      expect(result.value).toBe('[click](url)');
+    });
+
+    it('link: без выделения — плейсхолдер', () => {
+      const result = insertMarkdown('', 0, 0, 'link');
+      expect(result.value).toBe('[текст](url)');
+      expect(result.selectionStart).toBe(1);
+      expect(result.selectionEnd).toBe(6);
+    });
+
+    it('image: оборачивает в ![](url)', () => {
+      const result = insertMarkdown('pic', 0, 3, 'image');
+      expect(result.value).toBe('![pic](url)');
+    });
+  });
+
+  describe('prefixLine — вставка префикса в начало строки', () => {
+    it('blockquote: добавляет > к строке с текстом', () => {
+      const result = insertMarkdown('some text', 3, 3, 'blockquote');
+      expect(result.value).toBe('> some text');
+    });
+
+    it('blockquote: пустая строка — плейсхолдер', () => {
+      const result = insertMarkdown('', 0, 0, 'blockquote');
+      expect(result.value).toBe('> цитата');
+    });
+
+    it('unorderedList: добавляет - к строке', () => {
+      const result = insertMarkdown('item', 0, 0, 'unorderedList');
+      expect(result.value).toBe('- item');
+    });
+
+    it('orderedList: добавляет 1. к строке', () => {
+      const result = insertMarkdown('item', 0, 0, 'orderedList');
+      expect(result.value).toBe('1. item');
+    });
+
+    it('heading1: добавляет # к строке', () => {
+      const result = insertMarkdown('title', 0, 0, 'heading1');
+      expect(result.value).toBe('# title');
+    });
+
+    it('heading2: добавляет ## к строке', () => {
+      const result = insertMarkdown('title', 2, 2, 'heading2');
+      expect(result.value).toBe('## title');
+    });
+
+    it('heading3: добавляет ### к строке', () => {
+      const result = insertMarkdown('title', 0, 0, 'heading3');
+      expect(result.value).toBe('### title');
+    });
+
+    it('работает со второй строкой в многострочном тексте', () => {
+      const text = 'first line\nsecond line';
+      // Выделяем "second line" (индексы 11-22)
+      const result = insertMarkdown(text, 11, 22, 'bold');
+      expect(result.value).toBe('first line\n**second line**');
+    });
+
+    it('heading на второй строке', () => {
+      const text = 'first\nsecond';
+      const result = insertMarkdown(text, 8, 8, 'heading1');
+      expect(result.value).toBe('first\n# second');
+    });
+  });
+});

--- a/src/test/markdownInsert.test.ts
+++ b/src/test/markdownInsert.test.ts
@@ -99,4 +99,57 @@ describe('insertMarkdown', () => {
       expect(result.value).toBe('first\n# second');
     });
   });
+
+  describe('новые действия: table, checkbox, codeBlock, horizontalRule', () => {
+    it('table: вставляет шаблон таблицы', () => {
+      const result = insertMarkdown('', 0, 0, 'table');
+      expect(result.value).toBe('| Заголовок | Заголовок |\n|---|---|\n| Ячейка | Ячейка |');
+      // Выделяет первый «Заголовок»
+      expect(result.selectionStart).toBe(2);
+      expect(result.selectionEnd).toBe(11);
+    });
+
+    it('table: добавляет перенос строки если вставка не в начале', () => {
+      const result = insertMarkdown('текст', 5, 5, 'table');
+      expect(result.value).toContain('\n| Заголовок');
+    });
+
+    it('checkbox: добавляет - [ ] к строке с текстом', () => {
+      const result = insertMarkdown('задача', 0, 0, 'checkbox');
+      expect(result.value).toBe('- [ ] задача');
+    });
+
+    it('checkbox: пустая строка — плейсхолдер', () => {
+      const result = insertMarkdown('', 0, 0, 'checkbox');
+      expect(result.value).toBe('- [ ] задача');
+      expect(result.selectionStart).toBe(6);
+      expect(result.selectionEnd).toBe(12);
+    });
+
+    it('codeBlock: оборачивает выделение в тройные кавычки', () => {
+      const result = insertMarkdown('console.log()', 0, 13, 'codeBlock');
+      expect(result.value).toBe('```\nconsole.log()\n```');
+      expect(result.selectionStart).toBe(4);
+      expect(result.selectionEnd).toBe(17);
+    });
+
+    it('codeBlock: без выделения — плейсхолдер', () => {
+      const result = insertMarkdown('', 0, 0, 'codeBlock');
+      expect(result.value).toBe('```\nкод\n```');
+      expect(result.selectionStart).toBe(4);
+      expect(result.selectionEnd).toBe(7);
+    });
+
+    it('horizontalRule: вставляет ---', () => {
+      const result = insertMarkdown('', 0, 0, 'horizontalRule');
+      expect(result.value).toBe('---\n');
+      expect(result.selectionStart).toBe(0);
+      expect(result.selectionEnd).toBe(3);
+    });
+
+    it('horizontalRule: добавляет перенос строки если не в начале', () => {
+      const result = insertMarkdown('текст', 5, 5, 'horizontalRule');
+      expect(result.value).toBe('текст\n---\n');
+    });
+  });
 });

--- a/src/utils/markdownInsert.ts
+++ b/src/utils/markdownInsert.ts
@@ -1,0 +1,104 @@
+// Утилита для вставки Markdown-разметки в textarea
+
+export interface InsertResult {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+// Оборачивает выделенный текст или вставляет шаблон
+function wrapSelection(
+  text: string,
+  start: number,
+  end: number,
+  before: string,
+  after: string,
+  placeholder: string,
+): InsertResult {
+  const selected = text.slice(start, end);
+  if (selected) {
+    const newText = text.slice(0, start) + before + selected + after + text.slice(end);
+    return {
+      value: newText,
+      selectionStart: start + before.length,
+      selectionEnd: start + before.length + selected.length,
+    };
+  }
+  const insert = before + placeholder + after;
+  const newText = text.slice(0, start) + insert + text.slice(end);
+  return {
+    value: newText,
+    selectionStart: start + before.length,
+    selectionEnd: start + before.length + placeholder.length,
+  };
+}
+
+// Вставляет префикс в начало строки
+function prefixLine(
+  text: string,
+  start: number,
+  prefix: string,
+  placeholder: string,
+): InsertResult {
+  // Находим начало текущей строки
+  const lineStart = text.lastIndexOf('\n', start - 1) + 1;
+  const lineEnd = text.indexOf('\n', start);
+  const actualEnd = lineEnd === -1 ? text.length : lineEnd;
+  const lineContent = text.slice(lineStart, actualEnd);
+
+  if (lineContent.trim()) {
+    const newText = text.slice(0, lineStart) + prefix + text.slice(lineStart);
+    return {
+      value: newText,
+      selectionStart: lineStart + prefix.length,
+      selectionEnd: actualEnd + prefix.length,
+    };
+  }
+  const insert = prefix + placeholder;
+  const newText = text.slice(0, lineStart) + insert + text.slice(lineStart);
+  return {
+    value: newText,
+    selectionStart: lineStart + prefix.length,
+    selectionEnd: lineStart + prefix.length + placeholder.length,
+  };
+}
+
+export type MarkdownAction =
+  | 'bold' | 'italic' | 'strikethrough'
+  | 'link' | 'image' | 'inlineCode'
+  | 'blockquote' | 'unorderedList' | 'orderedList'
+  | 'heading1' | 'heading2' | 'heading3';
+
+export function insertMarkdown(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+  action: MarkdownAction,
+): InsertResult {
+  switch (action) {
+    case 'bold':
+      return wrapSelection(text, selectionStart, selectionEnd, '**', '**', 'текст');
+    case 'italic':
+      return wrapSelection(text, selectionStart, selectionEnd, '*', '*', 'текст');
+    case 'strikethrough':
+      return wrapSelection(text, selectionStart, selectionEnd, '~~', '~~', 'текст');
+    case 'inlineCode':
+      return wrapSelection(text, selectionStart, selectionEnd, '`', '`', 'код');
+    case 'link':
+      return wrapSelection(text, selectionStart, selectionEnd, '[', '](url)', 'текст');
+    case 'image':
+      return wrapSelection(text, selectionStart, selectionEnd, '![', '](url)', 'alt');
+    case 'blockquote':
+      return prefixLine(text, selectionStart, '> ', 'цитата');
+    case 'unorderedList':
+      return prefixLine(text, selectionStart, '- ', 'элемент');
+    case 'orderedList':
+      return prefixLine(text, selectionStart, '1. ', 'элемент');
+    case 'heading1':
+      return prefixLine(text, selectionStart, '# ', 'Заголовок');
+    case 'heading2':
+      return prefixLine(text, selectionStart, '## ', 'Заголовок');
+    case 'heading3':
+      return prefixLine(text, selectionStart, '### ', 'Заголовок');
+  }
+}


### PR DESCRIPTION
## Summary\n- Исправлены шорткаты: `e.key` → `e.code` для раскладко-зависимых клавиш (Shift+8, Shift+7, Shift+., Shift+X/K/S/T)\n- Добавлены новые MarkdownAction: `table`, `checkbox`, `codeBlock`, `horizontalRule`\n- Новые шорткаты: `Ctrl+T` (таблица), `Ctrl+Shift+C` (чекбокс), `Ctrl+Shift+E` (блок кода), `Ctrl+Shift+-` (горизонтальная линия)\n- Контекстное меню в source-режиме (правый клик) с тремя группами: Форматирование, Вставка, Блоки\n- Обновлены i18n (ru/en), справочник шорткатов, 8 новых тестов\n\nCloses #1, closes #2\n\n## Test plan\n- [x] `npx vitest run` — все 56 тестов проходят\n- [x] `npx tsc --noEmit` — без ошибок\n- [ ] Проверить шорткаты на русской и английской раскладках\n- [ ] Проверить контекстное меню правым кликом в source-режиме\n- [ ] Проверить вкладку Справка → Горячие клавиши\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"