### PR TITLE
feat: local image preview and asset insertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-redactor",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1428,6 +1428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3491,6 +3497,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-opener = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown-redactor"
-version = "0.4.0"
+version = "0.5.0"
 description = "Markdown-редактор для Windows 11"
 authors = ["Brian"]
 edition = "2021"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -18,6 +18,10 @@
     "fs:default",
     "fs:allow-read-text-file",
     "fs:allow-write-text-file",
+    {
+      "identifier": "fs:allow-exists",
+      "allow": [{ "path": "**" }]
+    },
     "opener:default",
     "opener:allow-default-urls",
     "store:default"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,11 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["**"]
+      }
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Markdown Redactor",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "com.brian.markdown-redactor",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { useTheme } from './hooks/useTheme';
 import { useAppStore } from './stores/appStore';
 import { getActiveEditor } from './utils/editorBridge';
 import * as tauri from './utils/tauri';
+import { findBaseDir } from './utils/paths';
 import './App.css';
 
 type MarkdownAction =
@@ -30,7 +31,7 @@ type MarkdownAction =
     };
 
 function App() {
-  const { open, save, saveAs } = useFile();
+  const { open, save, saveAs, insertAsset } = useFile();
   const { changeFontSize, fontSize, language } = useSettings();
   const { toggleTheme } = useTheme();
   const editorMode = useAppStore((s) => s.editorMode);
@@ -65,8 +66,12 @@ function App() {
     tauri.getPendingFile().then(async (filePath) => {
       if (filePath) {
         try {
-          const content = await tauri.readFile(filePath);
+          const [content, base] = await Promise.all([
+            tauri.readFile(filePath),
+            findBaseDir(filePath),
+          ]);
           useAppStore.getState().setFilePath(filePath);
+          useAppStore.getState().setBaseDir(base);
           useAppStore.getState().setContent(content);
           useAppStore.getState().setDirty(false);
         } catch (e) {
@@ -285,7 +290,16 @@ function App() {
         inline: false,
       });
     }
-  }, [open, save, saveAs, toggleTheme, editorMode, setEditorMode, changeFontSize, fontSize, applyMarkdownAction, placeholders]);
+    // Ctrl+Shift+A — Вставить ассет из assets/
+    if (isCtrl && isShift && !isAlt && code === 'KeyA') {
+      e.preventDefault();
+      insertAsset().then((md) => {
+        if (md) {
+          applyMarkdownAction({ type: 'insert', text: md, inline: false });
+        }
+      });
+    }
+  }, [open, save, saveAs, toggleTheme, editorMode, setEditorMode, changeFontSize, fontSize, applyMarkdownAction, placeholders, insertAsset]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -5,6 +5,7 @@ import '@milkdown/crepe/theme/frame.css';
 import { useAppStore } from '../../stores/appStore';
 import { setActiveEditor } from '../../utils/editorBridge';
 import { renderMermaidPreview } from '../../utils/mermaid';
+import { resolveImageSrc } from '../../utils/paths';
 import './editor.css';
 
 // Извлечь YAML frontmatter из markdown-контента.
@@ -15,7 +16,7 @@ function splitFrontmatter(content: string): [string, string] {
   return ['', content];
 }
 
-function createCrepeConfig(defaultValue: string) {
+function createCrepeConfig(defaultValue: string, baseDir: string | null) {
   return {
     defaultValue,
     features: {
@@ -46,6 +47,13 @@ function createCrepeConfig(defaultValue: string) {
         },
         previewOnlyByDefault: true,
       },
+      [CrepeFeature.ImageBlock]: {
+        proxyDomURL: (url: string): string | Promise<string> => {
+          if (!url || /^(https?:|data:|blob:)/.test(url)) return url;
+          if (!baseDir) return url;
+          return resolveImageSrc(url, baseDir);
+        },
+      },
     },
   };
 }
@@ -57,6 +65,7 @@ export function Editor() {
   const crepeRef = useRef<Crepe | null>(null);
 
   const content = useAppStore((s) => s.content);
+  const baseDir = useAppStore((s) => s.baseDir);
   const setContent = useAppStore((s) => s.setContent);
   const fontFamily = useAppStore((s) => s.fontFamily);
   const fontSize = useAppStore((s) => s.fontSize);
@@ -81,7 +90,7 @@ export function Editor() {
   const frontmatterRef = useRef('');
 
   // Создание экземпляра Crepe
-  const buildCrepe = useCallback((root: HTMLElement, value: string) => {
+  const buildCrepe = useCallback((root: HTMLElement, value: string, currentBaseDir: string | null) => {
     // Очистить предыдущие обработчики взаимодействия
     interactionCleanupRef.current?.();
 
@@ -104,7 +113,7 @@ export function Editor() {
 
     const crepe = new Crepe({
       root,
-      ...createCrepeConfig(body),
+      ...createCrepeConfig(body, currentBaseDir),
     });
 
     crepe.on((listener) => {
@@ -126,7 +135,7 @@ export function Editor() {
   useEffect(() => {
     if (!editorRef.current) return;
 
-    const crepe = buildCrepe(editorRef.current, content);
+    const crepe = buildCrepe(editorRef.current, content, baseDir);
     crepe.create().then(() => {
       crepeRef.current = crepe;
       setActiveEditor(crepe.editor);
@@ -150,14 +159,14 @@ export function Editor() {
 
       setActiveEditor(null);
       crepeRef.current.destroy().then(() => {
-        const crepe = buildCrepe(root, content);
+        const crepe = buildCrepe(root, content, baseDir);
         crepe.create().then(() => {
           crepeRef.current = crepe;
           setActiveEditor(crepe.editor);
         });
       });
     }
-  }, [content, buildCrepe]);
+  }, [content, baseDir, buildCrepe]);
 
   // Синхронизация source → store при переключении обратно в visual
   const prevMode = useRef(editorMode);
@@ -169,7 +178,7 @@ export function Editor() {
       const currentContent = contentRef.current;
       setActiveEditor(null);
       crepeRef.current.destroy().then(() => {
-        const crepe = buildCrepe(root, currentContent);
+        const crepe = buildCrepe(root, currentContent, baseDir);
         crepe.create().then(() => {
           crepeRef.current = crepe;
           setActiveEditor(crepe.editor);
@@ -177,7 +186,7 @@ export function Editor() {
       });
     }
     prevMode.current = editorMode;
-  }, [editorMode, buildCrepe]);
+  }, [editorMode, baseDir, buildCrepe]);
 
   // Динамическое обновление шрифта и размера через CSS-переменные
   useEffect(() => {

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -75,6 +75,14 @@ export function Toolbar() {
           >
             ↻
           </button>
+          <button
+            className="toolbar-btn"
+            onClick={() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', code: 'KeyA', ctrlKey: true, shiftKey: true, bubbles: true }))}
+            disabled={!filePath}
+            title={t.insertAssetTooltip}
+          >
+            {t.insertAsset}
+          </button>
         </div>
 
         <div className="toolbar-separator" />

--- a/src/hooks/useFile.ts
+++ b/src/hooks/useFile.ts
@@ -1,27 +1,34 @@
 import { useCallback } from 'react';
 import { useAppStore } from '../stores/appStore';
 import * as tauri from '../utils/tauri';
+import { findBaseDir, pickAndFormatAsset } from '../utils/paths';
 
 export function useFile() {
   const {
     filePath,
+    baseDir,
     content,
     isDirty,
     setContent,
     setFilePath,
+    setBaseDir,
     setDirty,
   } = useAppStore();
 
   const open = useCallback(async () => {
     try {
       const file = await tauri.openFile();
+      // Вычислить baseDir ДО установки контента,
+      // чтобы редактор пересоздался с корректным baseDir
+      const base = await findBaseDir(file.path);
       setFilePath(file.path);
+      setBaseDir(base);
       setContent(file.content);
       setDirty(false);
     } catch {
       // Пользователь отменил диалог или произошла ошибка
     }
-  }, [setContent, setDirty, setFilePath]);
+  }, [setContent, setDirty, setFilePath, setBaseDir]);
 
   const save = useCallback(async () => {
     if (!filePath) {
@@ -58,5 +65,14 @@ export function useFile() {
     }
   }, [filePath, setContent, setDirty]);
 
-  return { filePath, content, isDirty, open, save, saveAs, reload, setContent };
+  // Выбрать файл из assets/ и вернуть готовый markdown
+  const insertAsset = useCallback(async (): Promise<string | null> => {
+    try {
+      return await pickAndFormatAsset(baseDir);
+    } catch {
+      return null;
+    }
+  }, [baseDir]);
+
+  return { filePath, content, isDirty, open, save, saveAs, reload, insertAsset, setContent };
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -47,6 +47,8 @@ export const en: Translations = {
   decreaseFontTooltip: 'Decrease font (Ctrl+-)',
   increaseFontTooltip: 'Increase font (Ctrl++)',
   pageWidthTooltip: 'Page width (px)',
+  insertAsset: 'Insert file',
+  insertAssetTooltip: 'Insert asset (Ctrl+Shift+A)',
 
   // Help
   helpTitle: 'Help',
@@ -132,6 +134,7 @@ export const en: Translations = {
         { keys: 'Ctrl+Alt+C', description: 'Code block (```...```)' },
         { keys: 'Ctrl+K', description: 'Link ([text](url))' },
         { keys: 'Ctrl+Shift+K', description: 'Image (![alt](url))' },
+        { keys: 'Ctrl+Shift+A', description: 'Insert file from assets/' },
         { keys: 'Ctrl+Alt+T', description: 'Table' },
         { keys: 'Ctrl+Alt+X', description: 'Checkbox (- [ ])' },
       ],

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -45,6 +45,8 @@ export const ru = {
   decreaseFontTooltip: 'Уменьшить шрифт (Ctrl+-)',
   increaseFontTooltip: 'Увеличить шрифт (Ctrl++)',
   pageWidthTooltip: 'Ширина страницы (px)',
+  insertAsset: 'Вставить файл',
+  insertAssetTooltip: 'Вставить ассет (Ctrl+Shift+A)',
 
   // Справка
   helpTitle: 'Справка',
@@ -130,6 +132,7 @@ export const ru = {
         { keys: 'Ctrl+Alt+C', description: 'Блок кода (```...```)' },
         { keys: 'Ctrl+K', description: 'Ссылка ([текст](url))' },
         { keys: 'Ctrl+Shift+K', description: 'Изображение (![alt](url))' },
+        { keys: 'Ctrl+Shift+A', description: 'Вставить файл из assets/' },
         { keys: 'Ctrl+Alt+T', description: 'Таблица' },
         { keys: 'Ctrl+Alt+X', description: 'Чекбокс (- [ ])' },
       ],

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -5,6 +5,7 @@ import type { Language } from '../i18n';
 export const useAppStore = create<AppState>((set) => ({
   // Файл
   filePath: null,
+  baseDir: null,
   content: '',
   isDirty: false,
 
@@ -22,6 +23,7 @@ export const useAppStore = create<AppState>((set) => ({
     state.content === content ? {} : { content, isDirty: true }
   ),
   setFilePath: (filePath) => set({ filePath }),
+  setBaseDir: (baseDir) => set({ baseDir }),
   setDirty: (isDirty) => set({ isDirty }),
   setFontFamily: (fontFamily) => set({ fontFamily }),
   setFontSize: (fontSize) => set({ fontSize }),

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,6 +3,25 @@ import '@testing-library/jest-dom';
 // Мок для Tauri API, чтобы тесты работали без Tauri runtime
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
+  convertFileSrc: vi.fn((path: string) => `https://asset.localhost/${encodeURIComponent(path)}`),
+}));
+
+vi.mock('@tauri-apps/api/path', () => ({
+  dirname: vi.fn(async (path: string) => {
+    const sep = path.includes('/') ? '/' : '\\';
+    const parts = path.split(sep);
+    parts.pop();
+    return parts.join(sep) || path;
+  }),
+  join: vi.fn(async (...parts: string[]) => parts.join('\\')),
+}));
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  exists: vi.fn(async () => false),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: vi.fn(async () => null),
 }));
 
 vi.mock('@tauri-apps/api/window', () => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export type EditorMode = 'visual' | 'source';
 export interface AppState {
   // Файл
   filePath: string | null;
+  baseDir: string | null;
   content: string;
   isDirty: boolean;
 
@@ -34,6 +35,7 @@ export interface AppState {
   // Действия
   setContent: (content: string) => void;
   setFilePath: (path: string | null) => void;
+  setBaseDir: (baseDir: string | null) => void;
   setDirty: (dirty: boolean) => void;
   setFontFamily: (fontFamily: string) => void;
   setFontSize: (fontSize: number) => void;

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,76 @@
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { dirname, join } from '@tauri-apps/api/path';
+import { exists } from '@tauri-apps/plugin-fs';
+import { open } from '@tauri-apps/plugin-dialog';
+
+// Максимальная глубина поиска папки assets/ вверх по дереву директорий
+const MAX_DEPTH = 5;
+
+// Найти базовую директорию, содержащую папку assets/.
+// Идёт вверх от директории файла, проверяя наличие assets/ на каждом уровне.
+// Возвращает найденную директорию или родительскую директорию файла как fallback.
+export async function findBaseDir(filePath: string): Promise<string> {
+  const fileDir = await dirname(filePath);
+
+  try {
+    let dir = fileDir;
+    for (let i = 0; i < MAX_DEPTH; i++) {
+      const assetsPath = await join(dir, 'assets');
+      if (await exists(assetsPath)) {
+        return dir;
+      }
+      const parent = await dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch (e) {
+    console.warn('[paths] findBaseDir: ошибка, fallback на директорию файла', e);
+  }
+
+  return fileDir;
+}
+
+// Преобразовать относительный путь изображения в URL для отображения в webview.
+// Абсолютные URL (http/https/data/blob) возвращаются без изменений.
+export async function resolveImageSrc(src: string, baseDir: string | null): Promise<string> {
+  if (!src || /^(https?:|data:|blob:)/.test(src)) return src;
+  if (!baseDir) return src;
+
+  const absolutePath = await join(baseDir, src);
+  return convertFileSrc(absolutePath);
+}
+
+const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp'];
+
+// Открыть диалог выбора файла в папке assets/ и вернуть готовый markdown.
+// Для картинок: ![имя](assets/папка/файл.png)
+// Для остальных: [имя](assets/папка/файл.ext)
+export async function pickAndFormatAsset(baseDir: string | null): Promise<string | null> {
+  const defaultPath = baseDir ? await join(baseDir, 'assets') : undefined;
+
+  const selected = await open({
+    defaultPath,
+    multiple: false,
+    directory: false,
+    filters: [{
+      name: 'Assets',
+      extensions: ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'pdf', 'zip', 'mp4', 'webm'],
+    }],
+  });
+
+  if (!selected || typeof selected !== 'string') return null;
+
+  // Нормализовать слэши и найти assets/ в пути
+  const normalized = selected.replace(/\\/g, '/');
+  const idx = normalized.indexOf('/assets/');
+  if (idx === -1) return null;
+
+  const relativePath = normalized.substring(idx + 1); // "assets/папка/файл.png"
+  const fileName = relativePath.split('/').pop() || '';
+  const ext = (fileName.split('.').pop() || '').toLowerCase();
+
+  if (IMAGE_EXTS.includes(ext)) {
+    return `![${fileName}](${relativePath})`;
+  }
+  return `[${fileName}](${relativePath})`;
+}


### PR DESCRIPTION
## Summary
- Локальное превью изображений в визуальном редакторе через Tauri asset protocol (`convertFileSrc`)
- Новая утилита `paths.ts`: поиск `assets/` директории вверх по дереву, резолв относительных путей изображений
- Вставка ассетов из `assets/` через диалог выбора файла (Ctrl+Shift+A, кнопка в тулбаре)
- Версия обновлена до 0.5.0

## Test plan
- [ ] Открыть `.md` файл с относительными путями к изображениям — превью отображается корректно
- [ ] Ctrl+Shift+A открывает диалог в папке `assets/`, вставляет корректный markdown
- [ ] Изображения с абсолютными URL (http/https/data) не изменяются
- [ ] Файл без `assets/` в родительских директориях — graceful fallback
- [ ] Vitest тесты проходят

🤖 Generated with [Claude Code](https://claude.com/claude-code)