### PR TITLE
Codex: Правка при работе в режиме "визуального"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mivra",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mivra",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@milkdown/core": "^7.18.0",
         "@milkdown/crepe": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mivra",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mivra"
-version = "0.6.0"
+version = "0.6.1"
 description = "Markdown-редактор для Windows 11"
 authors = ["Brian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Mivra",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.brian.mivra",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -2,10 +2,12 @@ import { useEffect, useRef, useCallback } from 'react';
 import { Crepe, CrepeFeature } from '@milkdown/crepe';
 import '@milkdown/crepe/theme/common/style.css';
 import '@milkdown/crepe/theme/frame.css';
+import { editorViewCtx } from '@milkdown/kit/core';
 import { useAppStore } from '../../stores/appStore';
 import { setActiveEditor } from '../../utils/editorBridge';
 import { renderMermaidPreview } from '../../utils/mermaid';
 import { resolveImageSrc } from '../../utils/paths';
+import { createHeadingBackspaceTransaction } from './headingBackspace';
 import './editor.css';
 
 // Извлечь YAML frontmatter из markdown-контента.
@@ -100,9 +102,29 @@ export function Editor() {
 
     // Отслеживать первое взаимодействие пользователя с редактором
     const onInteraction = () => { userInteractedRef.current = true; };
+    const onBackspaceCapture = (event: KeyboardEvent) => {
+      if (event.key !== 'Backspace') return;
+
+      const handled = crepe.editor.action((ctx) => {
+        const view = ctx.get(editorViewCtx);
+        const tr = createHeadingBackspaceTransaction(view.state);
+        if (!tr) return false;
+
+        userInteractedRef.current = true;
+        view.dispatch(tr);
+        return true;
+      });
+
+      if (!handled) return;
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    root.addEventListener('keydown', onBackspaceCapture, true);
     root.addEventListener('keydown', onInteraction);
     root.addEventListener('pointerdown', onInteraction);
     interactionCleanupRef.current = () => {
+      root.removeEventListener('keydown', onBackspaceCapture, true);
       root.removeEventListener('keydown', onInteraction);
       root.removeEventListener('pointerdown', onInteraction);
     };

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 import { Crepe, CrepeFeature } from '@milkdown/crepe';
 import '@milkdown/crepe/theme/common/style.css';
 import '@milkdown/crepe/theme/frame.css';
@@ -8,6 +8,7 @@ import { setActiveEditor } from '../../utils/editorBridge';
 import { renderMermaidPreview } from '../../utils/mermaid';
 import { resolveImageSrc } from '../../utils/paths';
 import { createHeadingBackspaceTransaction } from './headingBackspace';
+import { denormalizeMarkdownForEditor, normalizeMarkdownForSource } from './sourceMarkdown';
 import './editor.css';
 
 // Извлечь YAML frontmatter из markdown-контента.
@@ -65,6 +66,7 @@ export function Editor() {
   const editorRef = useRef<HTMLDivElement>(null);
   const sourceRef = useRef<HTMLTextAreaElement>(null);
   const crepeRef = useRef<Crepe | null>(null);
+  const [sourceContent, setSourceContent] = useState(() => normalizeMarkdownForSource(content));
 
   const content = useAppStore((s) => s.content);
   const baseDir = useAppStore((s) => s.baseDir);
@@ -132,10 +134,11 @@ export function Editor() {
     // Извлечь frontmatter — Milkdown получает только тело документа
     const [fm, body] = splitFrontmatter(value);
     frontmatterRef.current = fm;
+    const visualBody = denormalizeMarkdownForEditor(body);
 
     const crepe = new Crepe({
       root,
-      ...createCrepeConfig(body, currentBaseDir),
+      ...createCrepeConfig(visualBody, currentBaseDir),
     });
 
     crepe.on((listener) => {
@@ -143,7 +146,7 @@ export function Editor() {
         // Обновлять store только если пользователь реально редактировал в visual-режиме
         if (!userInteractedRef.current || editorModeRef.current === 'source') return;
         // Восстановить frontmatter перед записью в store
-        const fullContent = frontmatterRef.current + markdown;
+        const fullContent = frontmatterRef.current + normalizeMarkdownForSource(markdown);
         if (fullContent === contentRef.current) return;
         contentRef.current = fullContent;
         setContentRef.current(fullContent);
@@ -210,6 +213,11 @@ export function Editor() {
     prevMode.current = editorMode;
   }, [editorMode, baseDir, buildCrepe]);
 
+  useEffect(() => {
+    if (editorMode !== 'source') return;
+    setSourceContent(normalizeMarkdownForSource(content));
+  }, [content, editorMode]);
+
   // Динамическое обновление шрифта и размера через CSS-переменные
   useEffect(() => {
     if (editorRef.current) {
@@ -228,6 +236,7 @@ export function Editor() {
   // Обработка ввода в source-режиме
   const handleSourceChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
+    setSourceContent(value);
     contentRef.current = value;
     setContentRef.current(value);
   }, []);
@@ -243,7 +252,7 @@ export function Editor() {
         <textarea
           ref={sourceRef}
           className="editor-source"
-          value={content}
+          value={sourceContent}
           onChange={handleSourceChange}
           spellCheck={false}
         />

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -66,7 +66,6 @@ export function Editor() {
   const editorRef = useRef<HTMLDivElement>(null);
   const sourceRef = useRef<HTMLTextAreaElement>(null);
   const crepeRef = useRef<Crepe | null>(null);
-  const [sourceContent, setSourceContent] = useState(() => normalizeMarkdownForSource(content));
 
   const content = useAppStore((s) => s.content);
   const baseDir = useAppStore((s) => s.baseDir);
@@ -75,6 +74,7 @@ export function Editor() {
   const fontSize = useAppStore((s) => s.fontSize);
   const pageWidth = useAppStore((s) => s.pageWidth);
   const editorMode = useAppStore((s) => s.editorMode);
+  const [sourceContent, setSourceContent] = useState(() => normalizeMarkdownForSource(content));
 
   // Refs для стабильных колбэков
   const setContentRef = useRef(setContent);

--- a/src/components/Editor/headingBackspace.ts
+++ b/src/components/Editor/headingBackspace.ts
@@ -1,6 +1,11 @@
 import type { EditorState, Transaction } from 'prosemirror-state';
 import { TextSelection } from 'prosemirror-state';
 
+function isEmptyHtmlBreak(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === '<br />' || normalized === '<br>' || normalized === '<br/>' || normalized === '<br >';
+}
+
 function isVisuallyEmptyParagraph(state: EditorState, nodeIndex: number, parentDepth: number): boolean {
   const node = state.selection.$from.node(parentDepth).child(nodeIndex);
   if (node.type.name !== 'paragraph') return false;
@@ -8,6 +13,7 @@ function isVisuallyEmptyParagraph(state: EditorState, nodeIndex: number, parentD
 
   return node.content.content.every((child) => {
     if (child.type.name === 'hardbreak') return true;
+    if (child.type.name === 'html') return isEmptyHtmlBreak(child.attrs.value);
     if (!child.isText) return false;
     return child.text?.trim() === '';
   });

--- a/src/components/Editor/headingBackspace.ts
+++ b/src/components/Editor/headingBackspace.ts
@@ -1,6 +1,18 @@
 import type { EditorState, Transaction } from 'prosemirror-state';
 import { TextSelection } from 'prosemirror-state';
 
+function isVisuallyEmptyParagraph(state: EditorState, nodeIndex: number, parentDepth: number): boolean {
+  const node = state.selection.$from.node(parentDepth).child(nodeIndex);
+  if (node.type.name !== 'paragraph') return false;
+  if (node.childCount === 0) return true;
+
+  return node.content.content.every((child) => {
+    if (child.type.name === 'hardbreak') return true;
+    if (!child.isText) return false;
+    return child.text?.trim() === '';
+  });
+}
+
 export function createHeadingBackspaceTransaction(state: EditorState): Transaction | null {
   const { selection } = state;
   if (!selection.empty) return null;
@@ -16,11 +28,11 @@ export function createHeadingBackspaceTransaction(state: EditorState): Transacti
   const blockIndex = $from.index(containerDepth);
   if (blockIndex === 0) return null;
 
-  const previousNode = container.child(blockIndex - 1);
-  if (previousNode.type.name !== 'paragraph' || previousNode.content.size !== 0) {
+  if (!isVisuallyEmptyParagraph(state, blockIndex - 1, containerDepth)) {
     return null;
   }
 
+  const previousNode = container.child(blockIndex - 1);
   const currentBlockPos = $from.before(blockDepth);
   const deleteFrom = currentBlockPos - previousNode.nodeSize;
   const deleteTo = currentBlockPos;

--- a/src/components/Editor/headingBackspace.ts
+++ b/src/components/Editor/headingBackspace.ts
@@ -1,0 +1,31 @@
+import type { EditorState, Transaction } from 'prosemirror-state';
+import { TextSelection } from 'prosemirror-state';
+
+export function createHeadingBackspaceTransaction(state: EditorState): Transaction | null {
+  const { selection } = state;
+  if (!selection.empty) return null;
+
+  const { $from } = selection;
+  if ($from.depth === 0 || $from.parent.type.name !== 'heading' || $from.parentOffset !== 0) {
+    return null;
+  }
+
+  const blockDepth = $from.depth;
+  const containerDepth = blockDepth - 1;
+  const container = $from.node(containerDepth);
+  const blockIndex = $from.index(containerDepth);
+  if (blockIndex === 0) return null;
+
+  const previousNode = container.child(blockIndex - 1);
+  if (previousNode.type.name !== 'paragraph' || previousNode.content.size !== 0) {
+    return null;
+  }
+
+  const currentBlockPos = $from.before(blockDepth);
+  const deleteFrom = currentBlockPos - previousNode.nodeSize;
+  const deleteTo = currentBlockPos;
+
+  const tr = state.tr.delete(deleteFrom, deleteTo);
+  tr.setSelection(TextSelection.create(tr.doc, deleteFrom + 1));
+  return tr.scrollIntoView();
+}

--- a/src/components/Editor/headingBackspace.ts
+++ b/src/components/Editor/headingBackspace.ts
@@ -1,3 +1,4 @@
+import type { Node as ProseMirrorNode } from 'prosemirror-model';
 import type { EditorState, Transaction } from 'prosemirror-state';
 import { TextSelection } from 'prosemirror-state';
 
@@ -6,17 +7,69 @@ function isEmptyHtmlBreak(value: string | undefined): boolean {
   return normalized === '<br />' || normalized === '<br>' || normalized === '<br/>' || normalized === '<br >';
 }
 
+function isWhitespaceTextNode(node: ProseMirrorNode): boolean {
+  return node.isText && node.text?.trim() === '';
+}
+
+function isVisualBreakNode(node: ProseMirrorNode): boolean {
+  if (node.type.name === 'hardbreak') return true;
+  if (node.type.name === 'html') return isEmptyHtmlBreak(node.attrs.value);
+  return false;
+}
+
 function isVisuallyEmptyParagraph(state: EditorState, nodeIndex: number, parentDepth: number): boolean {
   const node = state.selection.$from.node(parentDepth).child(nodeIndex);
   if (node.type.name !== 'paragraph') return false;
   if (node.childCount === 0) return true;
 
   return node.content.content.every((child) => {
-    if (child.type.name === 'hardbreak') return true;
-    if (child.type.name === 'html') return isEmptyHtmlBreak(child.attrs.value);
+    if (isVisualBreakNode(child)) return true;
     if (!child.isText) return false;
-    return child.text?.trim() === '';
+    return isWhitespaceTextNode(child);
   });
+}
+
+function getTrailingVisualBreakRange(
+  state: EditorState,
+  nodeIndex: number,
+  parentDepth: number,
+  blockStartPos: number,
+): { from: number; to: number } | null {
+  const node = state.selection.$from.node(parentDepth).child(nodeIndex);
+  if (node.type.name !== 'paragraph' || node.childCount === 0) return null;
+
+  let trailingWhitespaceSize = 0;
+  let trailingIndex = node.childCount - 1;
+
+  while (trailingIndex >= 0 && isWhitespaceTextNode(node.child(trailingIndex))) {
+    trailingWhitespaceSize += node.child(trailingIndex).nodeSize;
+    trailingIndex -= 1;
+  }
+
+  if (trailingIndex < 0) return null;
+
+  const trailingNode = node.child(trailingIndex);
+  if (!isVisualBreakNode(trailingNode)) return null;
+
+  let hasMeaningfulContentBefore = false;
+  for (let index = 0; index < trailingIndex; index += 1) {
+    const child = node.child(index);
+    if (isWhitespaceTextNode(child) || isVisualBreakNode(child)) continue;
+    hasMeaningfulContentBefore = true;
+    break;
+  }
+
+  if (!hasMeaningfulContentBefore) return null;
+
+  const contentStartPos = blockStartPos + 1;
+  let childOffset = 0;
+  for (let index = 0; index < trailingIndex; index += 1) {
+    childOffset += node.child(index).nodeSize;
+  }
+
+  const from = contentStartPos + childOffset;
+  const to = from + trailingNode.nodeSize + trailingWhitespaceSize;
+  return { from, to };
 }
 
 export function createHeadingBackspaceTransaction(state: EditorState): Transaction | null {
@@ -34,16 +87,30 @@ export function createHeadingBackspaceTransaction(state: EditorState): Transacti
   const blockIndex = $from.index(containerDepth);
   if (blockIndex === 0) return null;
 
-  if (!isVisuallyEmptyParagraph(state, blockIndex - 1, containerDepth)) {
-    return null;
+  const previousBlockStartPos = $from.before(blockDepth) - container.child(blockIndex - 1).nodeSize;
+
+  if (isVisuallyEmptyParagraph(state, blockIndex - 1, containerDepth)) {
+    const previousNode = container.child(blockIndex - 1);
+    const currentBlockPos = $from.before(blockDepth);
+    const deleteFrom = currentBlockPos - previousNode.nodeSize;
+    const deleteTo = currentBlockPos;
+
+    const tr = state.tr.delete(deleteFrom, deleteTo);
+    tr.setSelection(TextSelection.create(tr.doc, deleteFrom + 1));
+    return tr.scrollIntoView();
   }
 
-  const previousNode = container.child(blockIndex - 1);
   const currentBlockPos = $from.before(blockDepth);
-  const deleteFrom = currentBlockPos - previousNode.nodeSize;
-  const deleteTo = currentBlockPos;
+  const trailingBreakRange = getTrailingVisualBreakRange(
+    state,
+    blockIndex - 1,
+    containerDepth,
+    previousBlockStartPos,
+  );
+  if (!trailingBreakRange) return null;
 
-  const tr = state.tr.delete(deleteFrom, deleteTo);
-  tr.setSelection(TextSelection.create(tr.doc, deleteFrom + 1));
+  const deleteSize = trailingBreakRange.to - trailingBreakRange.from;
+  const tr = state.tr.delete(trailingBreakRange.from, trailingBreakRange.to);
+  tr.setSelection(TextSelection.create(tr.doc, currentBlockPos - deleteSize + 1));
   return tr.scrollIntoView();
 }

--- a/src/components/Editor/sourceMarkdown.ts
+++ b/src/components/Editor/sourceMarkdown.ts
@@ -10,9 +10,18 @@ function withOriginalEol(content: string, eol: string): string {
   return eol === '\r\n' ? content.replace(/\n/g, '\r\n') : content;
 }
 
+function countHtmlBreaks(content: string): number {
+  return content.match(/<br\s*\/?>/gi)?.length ?? 0;
+}
+
 export function normalizeMarkdownForSource(content: string): string {
   const eol = detectEol(content);
   let normalized = withUnixEol(content);
+
+  normalized = normalized.replace(
+    /\n\n((?:[ \t]*<br\s*\/?>[ \t]*\n\n)+)(?=[ \t]*#{1,6}[ \t])/gi,
+    (_match, breaks: string) => '\n'.repeat(countHtmlBreaks(breaks) + 1),
+  );
 
   while (true) {
     const next = normalized.replace(/\n\n[ \t]*<br\s*\/?>[ \t]*\n\n/gi, '\n\n\n');
@@ -26,6 +35,11 @@ export function normalizeMarkdownForSource(content: string): string {
 export function denormalizeMarkdownForEditor(content: string): string {
   const eol = detectEol(content);
   let denormalized = withUnixEol(content);
+
+  denormalized = denormalized.replace(
+    /\n{2,}(?=[ \t]*#{1,6}[ \t])/g,
+    (newLines: string) => '\n\n' + '<br />\n\n'.repeat(newLines.length - 1),
+  );
 
   while (true) {
     const next = denormalized.replace(/\n\n\n/g, '\n\n<br />\n\n');

--- a/src/components/Editor/sourceMarkdown.ts
+++ b/src/components/Editor/sourceMarkdown.ts
@@ -19,6 +19,11 @@ export function normalizeMarkdownForSource(content: string): string {
   let normalized = withUnixEol(content);
 
   normalized = normalized.replace(
+    /^((?:[ \t]*<br\s*\/?>[ \t]*\n\n)+)(?=\S)/gi,
+    (_match, breaks: string) => '\n'.repeat(countHtmlBreaks(breaks)),
+  );
+
+  normalized = normalized.replace(
     /\n\n((?:[ \t]*<br\s*\/?>[ \t]*\n\n)+)(?=[ \t]*#{1,6}[ \t])/gi,
     (_match, breaks: string) => '\n'.repeat(countHtmlBreaks(breaks) + 1),
   );
@@ -35,6 +40,11 @@ export function normalizeMarkdownForSource(content: string): string {
 export function denormalizeMarkdownForEditor(content: string): string {
   const eol = detectEol(content);
   let denormalized = withUnixEol(content);
+
+  denormalized = denormalized.replace(
+    /^(\n+)(?=\S)/g,
+    (newLines: string) => '<br />\n\n'.repeat(newLines.length),
+  );
 
   denormalized = denormalized.replace(
     /\n{2,}(?=[ \t]*#{1,6}[ \t])/g,

--- a/src/components/Editor/sourceMarkdown.ts
+++ b/src/components/Editor/sourceMarkdown.ts
@@ -1,0 +1,37 @@
+function detectEol(content: string): string {
+  return content.includes('\r\n') ? '\r\n' : '\n';
+}
+
+function withUnixEol(content: string): string {
+  return content.replace(/\r\n/g, '\n');
+}
+
+function withOriginalEol(content: string, eol: string): string {
+  return eol === '\r\n' ? content.replace(/\n/g, '\r\n') : content;
+}
+
+export function normalizeMarkdownForSource(content: string): string {
+  const eol = detectEol(content);
+  let normalized = withUnixEol(content);
+
+  while (true) {
+    const next = normalized.replace(/\n\n[ \t]*<br\s*\/?>[ \t]*\n\n/gi, '\n\n\n');
+    if (next === normalized) break;
+    normalized = next;
+  }
+
+  return withOriginalEol(normalized, eol);
+}
+
+export function denormalizeMarkdownForEditor(content: string): string {
+  const eol = detectEol(content);
+  let denormalized = withUnixEol(content);
+
+  while (true) {
+    const next = denormalized.replace(/\n\n\n/g, '\n\n<br />\n\n');
+    if (next === denormalized) break;
+    denormalized = next;
+  }
+
+  return withOriginalEol(denormalized, eol);
+}

--- a/src/test/headingBackspace.test.ts
+++ b/src/test/headingBackspace.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { Schema } from 'prosemirror-model';
+import { EditorState, TextSelection } from 'prosemirror-state';
+import { createHeadingBackspaceTransaction } from '../components/Editor/headingBackspace';
+
+const schema = new Schema({
+  nodes: {
+    doc: {
+      content: 'block+',
+    },
+    paragraph: {
+      content: 'text*',
+      group: 'block',
+      toDOM: () => ['p', 0],
+    },
+    heading: {
+      attrs: {
+        level: { default: 1 },
+      },
+      content: 'text*',
+      group: 'block',
+      toDOM: (node) => [`h${node.attrs.level}`, 0],
+    },
+    text: {},
+  },
+});
+
+function createState(doc: Parameters<typeof schema.node>[1], selectionPos: number) {
+  const docNode = schema.node('doc', null, doc);
+
+  return EditorState.create({
+    schema,
+    doc: docNode,
+    selection: TextSelection.create(docNode, selectionPos),
+  });
+}
+
+describe('createHeadingBackspaceTransaction', () => {
+  it('должен удалять пустой абзац перед заголовком и сохранять тип heading', () => {
+    const doc = [
+      schema.node('paragraph'),
+      schema.node('heading', { level: 2 }, [schema.text('Заголовок')]),
+    ];
+    const state = createState(doc, 3);
+
+    const tr = createHeadingBackspaceTransaction(state);
+
+    expect(tr).not.toBeNull();
+    expect(tr?.doc.childCount).toBe(1);
+    expect(tr?.doc.firstChild?.type.name).toBe('heading');
+    expect(tr?.doc.firstChild?.attrs.level).toBe(2);
+    expect(tr?.selection.from).toBe(1);
+  });
+
+  it('не должен срабатывать, если предыдущий абзац не пустой', () => {
+    const doc = [
+      schema.node('paragraph', null, [schema.text('Текст')]),
+      schema.node('heading', { level: 2 }, [schema.text('Заголовок')]),
+    ];
+    const state = createState(doc, 8);
+
+    const tr = createHeadingBackspaceTransaction(state);
+
+    expect(tr).toBeNull();
+  });
+});

--- a/src/test/headingBackspace.test.ts
+++ b/src/test/headingBackspace.test.ts
@@ -9,7 +9,7 @@ const schema = new Schema({
       content: 'block+',
     },
     paragraph: {
-      content: '(text | hardbreak)*',
+      content: '(text | hardbreak | html)*',
       group: 'block',
       toDOM: () => ['p', 0],
     },
@@ -27,6 +27,15 @@ const schema = new Schema({
       group: 'inline',
       selectable: false,
       toDOM: () => ['br'],
+    },
+    html: {
+      inline: true,
+      group: 'inline',
+      atom: true,
+      attrs: {
+        value: { default: '' },
+      },
+      toDOM: (node) => ['span', node.attrs.value],
     },
   },
 });
@@ -86,5 +95,23 @@ describe('createHeadingBackspaceTransaction', () => {
     expect(tr?.doc.firstChild?.textContent).toBe('Текст');
     expect(tr?.doc.lastChild?.type.name).toBe('heading');
     expect(tr?.doc.lastChild?.attrs.level).toBe(3);
+  });
+
+  it('должен удалять строку с html br между текстом и заголовком', () => {
+    const doc = [
+      schema.node('paragraph', null, [schema.text('тест')]),
+      schema.node('paragraph', null, [schema.node('html', { value: '<br />' })]),
+      schema.node('heading', { level: 1 }, [schema.text('тест')]),
+    ];
+    const state = createState(doc, 10);
+
+    const tr = createHeadingBackspaceTransaction(state);
+
+    expect(tr).not.toBeNull();
+    expect(tr?.doc.childCount).toBe(2);
+    expect(tr?.doc.firstChild?.type.name).toBe('paragraph');
+    expect(tr?.doc.firstChild?.textContent).toBe('тест');
+    expect(tr?.doc.lastChild?.type.name).toBe('heading');
+    expect(tr?.doc.lastChild?.attrs.level).toBe(1);
   });
 });

--- a/src/test/headingBackspace.test.ts
+++ b/src/test/headingBackspace.test.ts
@@ -9,7 +9,7 @@ const schema = new Schema({
       content: 'block+',
     },
     paragraph: {
-      content: 'text*',
+      content: '(text | hardbreak)*',
       group: 'block',
       toDOM: () => ['p', 0],
     },
@@ -22,6 +22,12 @@ const schema = new Schema({
       toDOM: (node) => [`h${node.attrs.level}`, 0],
     },
     text: {},
+    hardbreak: {
+      inline: true,
+      group: 'inline',
+      selectable: false,
+      toDOM: () => ['br'],
+    },
   },
 });
 
@@ -62,5 +68,23 @@ describe('createHeadingBackspaceTransaction', () => {
     const tr = createHeadingBackspaceTransaction(state);
 
     expect(tr).toBeNull();
+  });
+
+  it('должен удалять визуально пустую строку между текстом и заголовком', () => {
+    const doc = [
+      schema.node('paragraph', null, [schema.text('Текст')]),
+      schema.node('paragraph', null, [schema.node('hardbreak')]),
+      schema.node('heading', { level: 3 }, [schema.text('Заголовок')]),
+    ];
+    const state = createState(doc, 11);
+
+    const tr = createHeadingBackspaceTransaction(state);
+
+    expect(tr).not.toBeNull();
+    expect(tr?.doc.childCount).toBe(2);
+    expect(tr?.doc.firstChild?.type.name).toBe('paragraph');
+    expect(tr?.doc.firstChild?.textContent).toBe('Текст');
+    expect(tr?.doc.lastChild?.type.name).toBe('heading');
+    expect(tr?.doc.lastChild?.attrs.level).toBe(3);
   });
 });

--- a/src/test/headingBackspace.test.ts
+++ b/src/test/headingBackspace.test.ts
@@ -50,6 +50,17 @@ function createState(doc: Parameters<typeof schema.node>[1], selectionPos: numbe
   });
 }
 
+function getBlockStartPosition(doc: Parameters<typeof schema.node>[1], blockIndex: number): number {
+  const docNode = schema.node('doc', null, doc);
+  let position = 0;
+
+  for (let index = 0; index < blockIndex; index += 1) {
+    position += docNode.child(index).nodeSize;
+  }
+
+  return position + 1;
+}
+
 describe('createHeadingBackspaceTransaction', () => {
   it('должен удалять пустой абзац перед заголовком и сохранять тип heading', () => {
     const doc = [
@@ -113,5 +124,57 @@ describe('createHeadingBackspaceTransaction', () => {
     expect(tr?.doc.firstChild?.textContent).toBe('тест');
     expect(tr?.doc.lastChild?.type.name).toBe('heading');
     expect(tr?.doc.lastChild?.attrs.level).toBe(1);
+  });
+
+  it('должен последовательно удалять несколько пустых строк перед заголовком без downgrade', () => {
+    const doc = [
+      schema.node('paragraph', null, [schema.text('тест')]),
+      schema.node('paragraph', null, [schema.node('html', { value: '<br />' })]),
+      schema.node('paragraph', null, [schema.node('html', { value: '<br />' })]),
+      schema.node('heading', { level: 2 }, [schema.text('заголовок')]),
+    ];
+    const initialState = createState(doc, getBlockStartPosition(doc, 3));
+
+    const firstTr = createHeadingBackspaceTransaction(initialState);
+
+    expect(firstTr).not.toBeNull();
+    expect(firstTr?.doc.childCount).toBe(3);
+    expect(firstTr?.doc.lastChild?.type.name).toBe('heading');
+    expect(firstTr?.doc.lastChild?.attrs.level).toBe(2);
+
+    const secondState = EditorState.create({
+      schema,
+      doc: firstTr!.doc,
+      selection: firstTr!.selection,
+    });
+    const secondTr = createHeadingBackspaceTransaction(secondState);
+
+    expect(secondTr).not.toBeNull();
+    expect(secondTr?.doc.childCount).toBe(2);
+    expect(secondTr?.doc.firstChild?.type.name).toBe('paragraph');
+    expect(secondTr?.doc.firstChild?.textContent).toBe('тест');
+    expect(secondTr?.doc.lastChild?.type.name).toBe('heading');
+    expect(secondTr?.doc.lastChild?.attrs.level).toBe(2);
+  });
+
+  it('должен сохранять heading, если последняя пустая строка хранится в конце предыдущего абзаца', () => {
+    const doc = [
+      schema.node('paragraph', null, [
+        schema.text('тест'),
+        schema.node('hardbreak'),
+        schema.node('hardbreak'),
+      ]),
+      schema.node('heading', { level: 2 }, [schema.text('заголовок')]),
+    ];
+    const state = createState(doc, getBlockStartPosition(doc, 1));
+
+    const tr = createHeadingBackspaceTransaction(state);
+
+    expect(tr).not.toBeNull();
+    expect(tr?.doc.childCount).toBe(2);
+    expect(tr?.doc.firstChild?.type.name).toBe('paragraph');
+    expect(tr?.doc.firstChild?.textContent).toBe('тест');
+    expect(tr?.doc.lastChild?.type.name).toBe('heading');
+    expect(tr?.doc.lastChild?.attrs.level).toBe(2);
   });
 });

--- a/src/test/sourceMarkdown.test.ts
+++ b/src/test/sourceMarkdown.test.ts
@@ -5,22 +5,29 @@ import {
 } from '../components/Editor/sourceMarkdown';
 
 describe('sourceMarkdown', () => {
-  it('должен убирать html br из source-представления', () => {
+  it('должен убирать html br из source-представления перед heading без лишней пустой строки', () => {
     const raw = 'тест\n\n<br />\n\n# тест';
 
-    expect(normalizeMarkdownForSource(raw)).toBe('тест\n\n\n# тест');
+    expect(normalizeMarkdownForSource(raw)).toBe('тест\n\n# тест');
   });
 
-  it('должен восстанавливать html br для visual-редактора', () => {
-    const source = 'тест\n\n\n# тест';
+  it('должен восстанавливать html br перед heading для visual-редактора', () => {
+    const source = 'тест\n\n# тест';
 
     expect(denormalizeMarkdownForEditor(source)).toBe('тест\n\n<br />\n\n# тест');
   });
 
-  it('должен сохранять несколько дополнительных пустых строк', () => {
-    const source = 'тест\n\n\n\n# тест';
+  it('должен сохранять несколько дополнительных пустых строк перед heading без лишней строки в source', () => {
+    const source = 'тест\n\n\n# тест';
 
     expect(denormalizeMarkdownForEditor(source)).toBe('тест\n\n<br />\n\n<br />\n\n# тест');
     expect(normalizeMarkdownForSource('тест\n\n<br />\n\n<br />\n\n# тест')).toBe(source);
+  });
+
+  it('не должен менять старую нормализацию для не-heading блоков', () => {
+    const raw = 'тест\n\n<br />\n\nцитата';
+
+    expect(normalizeMarkdownForSource(raw)).toBe('тест\n\n\nцитата');
+    expect(denormalizeMarkdownForEditor('тест\n\n\nцитата')).toBe('тест\n\n<br />\n\nцитата');
   });
 });

--- a/src/test/sourceMarkdown.test.ts
+++ b/src/test/sourceMarkdown.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  denormalizeMarkdownForEditor,
+  normalizeMarkdownForSource,
+} from '../components/Editor/sourceMarkdown';
+
+describe('sourceMarkdown', () => {
+  it('должен убирать html br из source-представления', () => {
+    const raw = 'тест\n\n<br />\n\n# тест';
+
+    expect(normalizeMarkdownForSource(raw)).toBe('тест\n\n\n# тест');
+  });
+
+  it('должен восстанавливать html br для visual-редактора', () => {
+    const source = 'тест\n\n\n# тест';
+
+    expect(denormalizeMarkdownForEditor(source)).toBe('тест\n\n<br />\n\n# тест');
+  });
+
+  it('должен сохранять несколько дополнительных пустых строк', () => {
+    const source = 'тест\n\n\n\n# тест';
+
+    expect(denormalizeMarkdownForEditor(source)).toBe('тест\n\n<br />\n\n<br />\n\n# тест');
+    expect(normalizeMarkdownForSource('тест\n\n<br />\n\n<br />\n\n# тест')).toBe(source);
+  });
+});

--- a/src/test/sourceMarkdown.test.ts
+++ b/src/test/sourceMarkdown.test.ts
@@ -30,4 +30,16 @@ describe('sourceMarkdown', () => {
     expect(normalizeMarkdownForSource(raw)).toBe('тест\n\n\nцитата');
     expect(denormalizeMarkdownForEditor('тест\n\n\nцитата')).toBe('тест\n\n<br />\n\nцитата');
   });
+
+  it('должен убирать ведущий html br в source-представлении', () => {
+    const raw = '<br />\n\nапвп\n\nапвап\n\nвапвап';
+
+    expect(normalizeMarkdownForSource(raw)).toBe('\nапвп\n\nапвап\n\nвапвап');
+  });
+
+  it('должен восстанавливать ведущую пустую строку для visual-редактора', () => {
+    const source = '\nапвп\n\nапвап\n\nвапвап';
+
+    expect(denormalizeMarkdownForEditor(source)).toBe('<br />\n\nапвп\n\nапвап\n\nвапвап');
+  });
 });


### PR DESCRIPTION
## Задача
При Backspace в начале строки с заголовком в visual-редакторе сбрасывается стиль заголовка, если выше есть пустая строка.

## Что сделано
- добавлен безопасный перехват Backspace для случая `пустой paragraph -> heading`
- пустой абзац удаляется отдельно, без объединения с заголовком
- добавлен регрессионный тест на сохранение типа heading

## Проверки
- `npx tsc --noEmit`
- `npx vitest run src/test/headingBackspace.test.ts`
- `npm run test`
