### PR TITLE
Исправить release workflow для matrix-сборок

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         run: npm ci
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Что изменено

- Обновлён `tauri-apps/tauri-action` с `@v0` на `@v1` в release workflow.

## Причина

Release `v0.6.7` упал на matrix-сборке из-за гонки создания GitHub Release: один job успел создать release, следующий получил `Release already_exists`. В актуальной версии action matrix-загрузка assets в один release по `tagName` поддерживается корректно.

## Проверка

- Release run `26440517535` подтвердил корень: `Validation Failed: Release already_exists`, при этом первый asset уже был загружен.
- После merge workflow будет перезапущен через `workflow_dispatch` для `v0.6.7`.
