### PR TITLE
Исправить prepare-release для workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ steps.meta.outputs.tag_name }}
         run: |
           release_id="$(gh release view "$TAG_NAME" --json databaseId --jq .databaseId 2>/dev/null || true)"
@@ -40,10 +41,10 @@ jobs:
 
           | Платформа | Файл |
           |-----------|------|
-          | Windows | `.exe` |
-          | macOS (Apple Silicon) | `.dmg` (aarch64) |
-          | macOS (Intel) | `.dmg` (x64) |
-          | Linux | `.deb`, `.AppImage` |
+          | Windows | .exe |
+          | macOS (Apple Silicon) | .dmg (aarch64) |
+          | macOS (Intel) | .dmg (x64) |
+          | Linux | .deb, .AppImage |
           EOF
 
             gh release create "$TAG_NAME" \


### PR DESCRIPTION
## Что изменено

- Добавлен `GH_REPO` в `prepare-release`, чтобы `gh release view` работал без checkout.
- Убраны markdown backticks из shell heredoc, чтобы bash не выполнял `.exe`/`.dmg` как команды.

## Проверка

- Локально `GH_REPO=BrianIS8090/Mivra gh release view v0.6.7 --json databaseId --jq .databaseId` возвращает `329285801`.
- После merge workflow будет запущен повторно для `v0.6.7`.
